### PR TITLE
Add Arch Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ To install, use `ninja install`
 sudo ninja install
 ```
 
+## Arch Linux
+Arch Linux users can find Wingpanel Indicator Sys Monitor under the name [wingpanel-indicator-sys-monitor-git](https://aur.archlinux.org/packages/wingpanel-indicator-sys-monitor-git/) in the **AUR**:
+
+`$ aurman -S wingpanel-indicator-sys-monitor-git`


### PR DESCRIPTION
Arch Linux Support

I will support your application in Arch Linux.

Please add a section containing the following instruction:

## Arch Linux
Arch Linux users can find Wingpanel Indicator Sys Monitor under the name [wingpanel-indicator-sys-monitor-git](https://aur.archlinux.org/packages/wingpanel-indicator-sys-monitor-git/) in the **AUR**:

`$ aurman -S wingpanel-indicator-sys-monitor-git`

PS: I added your donation link in package description.