### PR TITLE
Add support for showing label/graph for CPU/RAM

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ shared_module(
     'src/Widgets/MainView.vala',
     'src/Widgets/SettingsView.vala',
     'src/Widgets/DisplayWidget.vala',
+    'src/Widgets/SysGraph.vala',
     link_args : ['-lm', '-nostartfiles'],
     name_prefix: '',
     dependencies: [

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ wingpanel_dep = dependency('wingpanel-2.0')
 shared_module(
     meson.project_name(),
     'src/Indicator.vala',
+    'src/Services/BackgroundManager.vala',
     'src/Services/CPU.vala',
     'src/Services/Net.vala',
     'src/Services/Memory.vala',

--- a/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
+++ b/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
@@ -17,12 +17,12 @@
 			<description></description>
 		</key>
     <key type="b" name="show-desr">
-			<default>true</default>
+			<default>false</default>
 			<summary>Show label for CPU/RAM in Wingpanel</summary>
 			<description></description>
 		</key>
     <key type="b" name="show-graph">
-			<default>true</default>
+			<default>false</default>
 			<summary>Show graph for CPU/RAM in Wingpanel</summary>
 			<description></description>
 		</key>

--- a/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
+++ b/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
@@ -16,6 +16,16 @@
 			<summary>Show Network usage in Wingpanel</summary>
 			<description></description>
 		</key>
+    <key type="b" name="show-desr">
+			<default>true</default>
+			<summary>Show label for CPU/RAM in Wingpanel</summary>
+			<description></description>
+		</key>
+    <key type="b" name="show-graph">
+			<default>true</default>
+			<summary>Show graph for CPU/RAM in Wingpanel</summary>
+			<description></description>
+		</key>
     <key type="b" name="show-icon">
 			<default>false</default>
 			<summary>Show sys-monitor icon in Wingpanel</summary>

--- a/src/Services/BackgroundManager.vala
+++ b/src/Services/BackgroundManager.vala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2011-2015 Wingpanel Developers (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+ 
+namespace SysMonitor.Services {
+
+    public enum BackgroundState {
+        LIGHT,
+        DARK,
+        MAXIMIZED,
+        TRANSLUCENT_DARK,
+        TRANSLUCENT_LIGHT
+    }
+
+    [DBus (name = "org.pantheon.gala.WingpanelInterface")]
+    public interface InterfaceBus : Object {
+        public signal void state_changed (BackgroundState state, uint animation_duration);
+
+        public abstract void initialize (int monitor, int panel_height) throws GLib.Error;
+        public abstract void remember_focused_window () throws GLib.Error;
+        public abstract void restore_focused_window () throws GLib.Error;
+        public abstract bool begin_grab_focused_window (int x, int y, int button, uint time, uint state) throws GLib.Error;
+    }
+
+    public class BackgroundManager : Object {
+        private const string DBUS_NAME = "org.pantheon.gala.WingpanelInterface";
+        private const string DBUS_PATH = "/org/pantheon/gala/WingpanelInterface";
+
+        private static BackgroundManager? instance = null;
+
+        private InterfaceBus? bus = null;
+
+        private BackgroundState current_state = BackgroundState.LIGHT;
+        private bool use_transparency = true;
+
+        private bool bus_available {
+            get {
+                return bus != null;
+            }
+        }
+
+        private int monitor;
+        private int panel_height;
+
+        public signal void background_state_changed (BackgroundState state, uint animation_duration);
+
+        public static void initialize (int monitor, int panel_height) {
+            var manager = BackgroundManager.get_default ();
+            manager.monitor = monitor;
+            manager.panel_height = panel_height;
+        }
+
+        private BackgroundManager () {
+            // TODO: Fix this
+            // PanelSettings.get_default ().notify["use-transparency"].connect (() => {
+            //     use_transparency = PanelSettings.get_default ().use_transparency;
+            //     state_updated ();
+            // });
+
+            // use_transparency = PanelSettings.get_default ().use_transparency;
+            use_transparency = true;
+
+            Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE,
+                () => connect_dbus (),
+                () => bus = null);
+        }
+
+        public void remember_window () {
+            if (!bus_available) {
+                return;
+            }
+
+            try {
+                bus.remember_focused_window ();
+            } catch (Error e) {
+                warning ("Remembering focused window failed: %s", e.message);
+            }
+        }
+
+        public void restore_window () {
+            if (!bus_available) {
+                return;
+            }
+
+            try {
+                bus.restore_focused_window ();
+            } catch (Error e) {
+                warning ("Restoring last focused window failed: %s", e.message);
+            }
+        }
+
+        public bool begin_grab_focused_window (int x, int y, int button, uint time, uint state) {
+            try {
+                return bus.begin_grab_focused_window (x, y, button, time, state);
+            } catch (Error e) {
+                warning ("Grabbing focused window failed: %s", e.message);
+            }
+
+            return false;
+        }
+
+        private bool connect_dbus () {
+            try {
+                bus = Bus.get_proxy_sync (BusType.SESSION, DBUS_NAME, DBUS_PATH);
+                bus.initialize (monitor, panel_height);
+            } catch (Error e) {
+                warning ("Connecting to \"%s\" failed: %s", DBUS_NAME, e.message);
+                return false;
+            }
+
+            bus.state_changed.connect ((state, animation_duration) => {
+                current_state = state;
+                state_updated (animation_duration);
+            });
+
+            state_updated ();
+            return true;
+        }
+
+        private void state_updated (uint animation_duration = 0) {
+            background_state_changed (use_transparency ? current_state : BackgroundState.MAXIMIZED, animation_duration);
+        }
+
+        public static BackgroundManager get_default () {
+            if (instance == null) {
+                instance = new BackgroundManager ();
+            }
+
+            return instance;
+        }
+    }
+}

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -25,6 +25,8 @@ public class SysMonitor.Services.SettingsManager : Granite.Services.Settings {
     public bool show_cpu { set; get; }
     public bool show_ram { set; get; }
     public bool show_network { set; get; }
+    public bool show_desr { set; get; }
+    public bool show_graph { set; get; }
     public bool show_icon { set; get; }
 
     public SettingsManager () {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -22,7 +22,9 @@
 public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private SysMonitor.Services.SettingsManager settings;
     private Gtk.Label cpu_label;
+    private Gtk.Label cpu_desr;
     private Gtk.Label ram_label;
+    private Gtk.Label ram_desr;
     private Gtk.Label network_down_label;
     private Gtk.Label network_up_label;
     private Gtk.Image icon;
@@ -41,7 +43,9 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings = SysMonitor.Services.SettingsManager.get_default ();
         icon = new Gtk.Image.from_icon_name ("computer-symbolic", Gtk.IconSize.MENU);
         cpu_label = new Gtk.Label ("CPU");
+        cpu_desr = new Gtk.Label ("CPU");
         ram_label = new Gtk.Label ("MEM");
+        ram_desr = new Gtk.Label ("MEM");
         network_down_label = new Gtk.Label ("DOWN");
         network_down_label.set_width_chars (8);
         network_up_label = new Gtk.Label ("UP");
@@ -50,31 +54,42 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         icon_up = new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.MENU);
 
         cpu_revealer = new Gtk.Revealer ();
-        cpu_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
-        update_cpu_revelear ();
-        cpu_revealer.add (cpu_label);
+        {
+            cpu_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            update_cpu_revelear ();
+            var grid_gpu = new Gtk.Grid ();
+            grid_gpu.attach (cpu_desr, 0, 0, 1, 1);
+            grid_gpu.attach_next_to (cpu_label, cpu_desr, Gtk.PositionType.RIGHT, 1, 1);
+            cpu_revealer.add (grid_gpu);
+        }
 
         ram_revealer = new Gtk.Revealer ();
-        ram_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
-        update_ram_revealer ();
-        ram_revealer.add (ram_label);
+        {
+            ram_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            update_ram_revealer ();
+            var grid_ram = new Gtk.Grid ();
+            grid_ram.attach (ram_desr, 0, 0, 1, 1);
+            grid_ram.attach_next_to (ram_label, ram_desr, Gtk.PositionType.RIGHT, 1, 1);
+            ram_revealer.add (grid_ram);
+        }
 
         network_revealer = new Gtk.Revealer ();
-        network_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+        {
+            network_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            update_network_revealer ();
+            var grid_network = new Gtk.Grid ();
+            grid_network.attach (icon_down, 0, 0, 1, 1);
+            grid_network.attach_next_to (network_down_label, icon_down, Gtk.PositionType.RIGHT, 1, 1);
+            grid_network.attach_next_to (icon_up, network_down_label, Gtk.PositionType.RIGHT, 1, 1);
+            grid_network.attach_next_to (network_up_label, icon_up, Gtk.PositionType.RIGHT, 1, 1);
+            network_revealer.add (grid_network);
+        }
         
-        var grid_network = new Gtk.Grid ();
-        update_network_revealer ();
-        grid_network.attach (icon_down, 0, 0, 1, 1);
-        grid_network.attach_next_to (network_down_label, icon_down, Gtk.PositionType.RIGHT, 1, 1);
-        grid_network.attach_next_to (icon_up, network_down_label, Gtk.PositionType.RIGHT, 1, 1);
-        grid_network.attach_next_to (network_up_label, icon_up, Gtk.PositionType.RIGHT, 1, 1);
-        network_revealer.add (grid_network);
 
         icon_revealer = new Gtk.Revealer ();
         icon_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
                                       update_icon_revealer ();
         icon_revealer.add (icon);
-
 
         settings.changed.connect (() => {
                                       update_icon_revealer ();

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -57,11 +57,9 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         cpu_label = new Gtk.Label ("CPU");
         cpu_graph = new Gtk.Label ("CPU");
         cpu_desr = new Gtk.Label ("CPU");
-        
         ram_label = new Gtk.Label ("MEM");
         ram_graph = new Gtk.Label ("MEM");
         ram_desr = new Gtk.Label ("MEM");
-        
         network_down_label = new Gtk.Label ("DOWN");
         network_down_label.set_width_chars (8);
         network_up_label = new Gtk.Label ("UP");
@@ -74,18 +72,16 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         cpu_graph_revealer = new Gtk.Revealer ();
         {
             cpu_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            cpu_desr_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            cpu_graph_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+    
             update_cpu_revelear ();
             update_cpu_desr_revelear ();
             update_cpu_graph_revelear ();
-            
+
             cpu_desr_revealer.add (cpu_desr);
             cpu_graph_revealer.add (cpu_graph);
-            
-            var grid_gpu = new Gtk.Grid ();
-            grid_gpu.attach (cpu_desr_revealer, 0, 0, 1, 1);
-            grid_gpu.attach_next_to (cpu_graph_revealer, cpu_desr_revealer, Gtk.PositionType.RIGHT, 1, 1);
-            grid_gpu.attach_next_to (cpu_label, cpu_graph_revealer, Gtk.PositionType.RIGHT, 1, 1);
-            cpu_revealer.add (grid_gpu);
+            cpu_revealer.add (cpu_label);
         }
 
         ram_revealer = new Gtk.Revealer ();
@@ -93,18 +89,16 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         ram_graph_revealer = new Gtk.Revealer ();
         {
             ram_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            ram_desr_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+            ram_graph_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
+
             update_ram_revealer ();
             update_ram_desr_revelear ();
             update_ram_graph_revelear ();
-            
+
             ram_desr_revealer.add (ram_desr);
             ram_graph_revealer.add (ram_graph);
-            
-            var grid_ram = new Gtk.Grid ();
-            grid_ram.attach (ram_desr_revealer, 0, 0, 1, 1);
-            grid_ram.attach_next_to (ram_graph_revealer, ram_desr_revealer, Gtk.PositionType.RIGHT, 1, 1);
-            grid_ram.attach_next_to (ram_label, ram_graph_revealer, Gtk.PositionType.RIGHT, 1, 1);
-            ram_revealer.add (grid_ram);
+            ram_revealer.add (ram_label);
         }
 
         network_revealer = new Gtk.Revealer ();
@@ -118,7 +112,6 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
             grid_network.attach_next_to (network_up_label, icon_up, Gtk.PositionType.RIGHT, 1, 1);
             network_revealer.add (grid_network);
         }
-        
 
         icon_revealer = new Gtk.Revealer ();
         icon_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
@@ -128,13 +121,20 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings.changed.connect (() => {
                                       update_icon_revealer ();
                                       update_cpu_revelear ();
+                                      update_cpu_desr_revelear ();
+                                      update_cpu_graph_revelear ();
                                       update_ram_revealer ();
+                                      update_ram_desr_revelear ();
+                                      update_ram_graph_revelear ();
                                       update_network_revealer ();
                                   });
-                                  
         add (icon_revealer);
         add (network_revealer);
+        add (cpu_desr_revealer);
+        add (cpu_graph_revealer);
         add (cpu_revealer);
+        add (ram_desr_revealer);
+        add (ram_graph_revealer);
         add (ram_revealer);
     }
 
@@ -158,11 +158,11 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     }
     
     private void update_cpu_desr_revelear () {
-        cpu_desr_revealer.reveal_child = settings.show_cpu;
+        cpu_desr_revealer.reveal_child = settings.show_cpu && settings.show_desr;
     }
 
     private void update_cpu_graph_revelear () {
-        cpu_graph_revealer.reveal_child = settings.show_cpu;
+        cpu_graph_revealer.reveal_child = settings.show_cpu && settings.show_graph;
     }
 
     private void update_ram_revealer () {
@@ -170,11 +170,11 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     }
 
     private void update_ram_desr_revelear () {
-        ram_desr_revealer.reveal_child = settings.show_ram;
+        ram_desr_revealer.reveal_child = settings.show_ram && settings.show_desr;
     }
 
     private void update_ram_graph_revelear () {
-        ram_graph_revealer.reveal_child = settings.show_ram;
+        ram_graph_revealer.reveal_child = settings.show_ram && settings.show_graph;
     }
 
     private void update_network_revealer () {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -21,10 +21,15 @@
 
 public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private SysMonitor.Services.SettingsManager settings;
+    
     private Gtk.Label cpu_label;
     private Gtk.Label cpu_desr;
+    private Gtk.Label cpu_graph;
+    
     private Gtk.Label ram_label;
     private Gtk.Label ram_desr;
+    private Gtk.Label ram_graph;
+    
     private Gtk.Label network_down_label;
     private Gtk.Label network_up_label;
     private Gtk.Image icon;
@@ -32,8 +37,15 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private Gtk.Image icon_up;
 
     private Gtk.Revealer cpu_revealer;
+    private Gtk.Revealer cpu_desr_revealer;
+    private Gtk.Revealer cpu_graph_revealer;
+    
     private Gtk.Revealer ram_revealer;
+    private Gtk.Revealer ram_desr_revealer;
+    private Gtk.Revealer ram_graph_revealer;
+    
     private Gtk.Revealer network_revealer;
+    
     private Gtk.Revealer icon_revealer;
 
     construct {
@@ -43,9 +55,13 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings = SysMonitor.Services.SettingsManager.get_default ();
         icon = new Gtk.Image.from_icon_name ("computer-symbolic", Gtk.IconSize.MENU);
         cpu_label = new Gtk.Label ("CPU");
+        cpu_graph = new Gtk.Label ("CPU");
         cpu_desr = new Gtk.Label ("CPU");
+        
         ram_label = new Gtk.Label ("MEM");
+        ram_graph = new Gtk.Label ("MEM");
         ram_desr = new Gtk.Label ("MEM");
+        
         network_down_label = new Gtk.Label ("DOWN");
         network_down_label.set_width_chars (8);
         network_up_label = new Gtk.Label ("UP");
@@ -54,22 +70,40 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         icon_up = new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.MENU);
 
         cpu_revealer = new Gtk.Revealer ();
+        cpu_desr_revealer = new Gtk.Revealer ();
+        cpu_graph_revealer = new Gtk.Revealer ();
         {
             cpu_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
             update_cpu_revelear ();
+            update_cpu_desr_revelear ();
+            update_cpu_graph_revelear ();
+            
+            cpu_desr_revealer.add (cpu_desr);
+            cpu_graph_revealer.add (cpu_graph);
+            
             var grid_gpu = new Gtk.Grid ();
-            grid_gpu.attach (cpu_desr, 0, 0, 1, 1);
-            grid_gpu.attach_next_to (cpu_label, cpu_desr, Gtk.PositionType.RIGHT, 1, 1);
+            grid_gpu.attach (cpu_desr_revealer, 0, 0, 1, 1);
+            grid_gpu.attach_next_to (cpu_graph_revealer, cpu_desr_revealer, Gtk.PositionType.RIGHT, 1, 1);
+            grid_gpu.attach_next_to (cpu_label, cpu_graph_revealer, Gtk.PositionType.RIGHT, 1, 1);
             cpu_revealer.add (grid_gpu);
         }
 
         ram_revealer = new Gtk.Revealer ();
+        ram_desr_revealer = new Gtk.Revealer ();
+        ram_graph_revealer = new Gtk.Revealer ();
         {
             ram_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
             update_ram_revealer ();
+            update_ram_desr_revelear ();
+            update_ram_graph_revelear ();
+            
+            ram_desr_revealer.add (ram_desr);
+            ram_graph_revealer.add (ram_graph);
+            
             var grid_ram = new Gtk.Grid ();
-            grid_ram.attach (ram_desr, 0, 0, 1, 1);
-            grid_ram.attach_next_to (ram_label, ram_desr, Gtk.PositionType.RIGHT, 1, 1);
+            grid_ram.attach (ram_desr_revealer, 0, 0, 1, 1);
+            grid_ram.attach_next_to (ram_graph_revealer, ram_desr_revealer, Gtk.PositionType.RIGHT, 1, 1);
+            grid_ram.attach_next_to (ram_label, ram_graph_revealer, Gtk.PositionType.RIGHT, 1, 1);
             ram_revealer.add (grid_ram);
         }
 
@@ -106,10 +140,12 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
 
     public void set_cpu (int cpu_usage) {
         cpu_label.set_label (this.format_int (cpu_usage));
+        cpu_graph.set_label (this.get_percent_progress_string (cpu_usage));
     }
 
     public void set_ram (int ram_usage) {
         ram_label.set_label (this.format_int (ram_usage));
+        ram_graph.set_label (this.get_percent_progress_string (ram_usage));
     }
 
     public void set_network (int bytes_out, int bytes_in) {
@@ -120,9 +156,25 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private void update_cpu_revelear () {
         cpu_revealer.reveal_child = settings.show_cpu;
     }
+    
+    private void update_cpu_desr_revelear () {
+        cpu_desr_revealer.reveal_child = settings.show_cpu;
+    }
+
+    private void update_cpu_graph_revelear () {
+        cpu_graph_revealer.reveal_child = settings.show_cpu;
+    }
 
     private void update_ram_revealer () {
         ram_revealer.reveal_child = settings.show_ram;
+    }
+
+    private void update_ram_desr_revelear () {
+        ram_desr_revealer.reveal_child = settings.show_ram;
+    }
+
+    private void update_ram_graph_revelear () {
+        ram_graph_revealer.reveal_child = settings.show_ram;
     }
 
     private void update_network_revealer () {
@@ -138,6 +190,36 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
             return "0%i%%".printf (number);
         } else {
             return "%i%%".printf (number);
+        }
+    }
+    
+    private string get_percent_progress_string(int number) {
+        if (number < 25) {
+            if (number < 12.5) {
+                return "░░░░";
+            } else {
+                return "▒░░░";
+            }
+        } else if (number < 50) {
+            if (number < 37.5) {
+                return "█░░░";
+            } else {
+                return "█▒░░";
+            }
+        } else if (number < 75) {
+            if (number < 62.5) {
+                return "██░░";
+            } else {
+                return "██▒░";
+            }
+        } else if (number < 100) {
+            if (number < 87.5) {
+                return "███░";
+            } else {
+                return "███▒";
+            }
+        } else {
+            return "████";
         }
     }
 }

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -19,66 +19,15 @@
  * Authored by: Tudor Plugaru <plugaru.tudor@gmail.com>
  */
 
-public class SysGraph : Gtk.DrawingArea {
-
-    private int _current_percent;
-    public int current_percent { 
-        set {_current_percent=value; redraw_canvas();} 
-        get {return _current_percent;} 
-    }
-
-    public SysGraph (int target_width, int target_height) {
-        set_size_request (target_width, target_height);
-        current_percent = 0;
-    }
-     
-    public override bool draw (Cairo.Context cr) {
-        int width = get_allocated_width ();
-        int height = get_allocated_height ();
-        
-        // Background
-        cr.set_source_rgb (0,0,0);
-        cr.rectangle (0, 0, width, height);
-        cr.fill ();
-        
-        // Percentage
-        var percent_height = (int) (((double)current_percent/100.0) * height);
-        var px = 0;
-        var py = height-percent_height;
-        cr.set_source_rgb (1,1,1);
-        cr.rectangle (px, py, width, percent_height);
-        cr.fill ();
-        
-        // Border
-        cr.set_source_rgb (0.2, 0.2, 0.2);
-        cr.rectangle (0, 0, width, height);
-        cr.stroke ();
-        
-        return false;
-    }
-    
-    private void redraw_canvas () {
-        var window = get_window ();
-        if (null == window) {
-            return;
-        }
-
-        var region = window.get_clip_region ();
-        // redraw the cairo canvas completely by exposing it
-        window.invalidate_region (region, true);
-        window.process_updates (true);
-    }
-}
-
 public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private SysMonitor.Services.SettingsManager settings;
     
     private Gtk.Label cpu_label;
     private Gtk.Label cpu_desr;
-    private SysGraph cpu_graph;
+    private SysMonitor.Widgets.SysGraph cpu_graph;
     private Gtk.Label ram_label;
     private Gtk.Label ram_desr;
-    private SysGraph ram_graph;
+    private SysMonitor.Widgets.SysGraph ram_graph;
     private Gtk.Label network_down_label;
     private Gtk.Label network_up_label;
     private Gtk.Image icon;
@@ -104,12 +53,10 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings = SysMonitor.Services.SettingsManager.get_default ();
         icon = new Gtk.Image.from_icon_name ("utilities-system-monitor-symbolic", Gtk.IconSize.MENU);
         cpu_label = new Gtk.Label ("CPU");
-        // cpu_graph = new Gtk.Label ("CPU");
-        cpu_graph = new SysGraph(14, Gtk.IconSize.MENU);
+        cpu_graph = new SysMonitor.Widgets.SysGraph(14, Gtk.IconSize.MENU);
         cpu_desr = new Gtk.Label ("CPU");
         ram_label = new Gtk.Label ("MEM");
-        // ram_graph = new Gtk.Label ("MEM");
-        ram_graph = new SysGraph(14, Gtk.IconSize.MENU);
+        ram_graph = new SysMonitor.Widgets.SysGraph(14, Gtk.IconSize.MENU);
         ram_desr = new Gtk.Label ("MEM");
         network_down_label = new Gtk.Label ("DOWN");
         network_down_label.set_width_chars (8);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -24,7 +24,7 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     
     private Gtk.Label cpu_label;
     private Gtk.Label cpu_desr;
-    private SysMonitor.Widgets.SysGraph cpu_graph;
+    private SysMonitor.Widgets.SysLineGraph cpu_graph;
     private Gtk.Label ram_label;
     private Gtk.Label ram_desr;
     private SysMonitor.Widgets.SysGraph ram_graph;
@@ -53,7 +53,7 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings = SysMonitor.Services.SettingsManager.get_default ();
         icon = new Gtk.Image.from_icon_name ("utilities-system-monitor-symbolic", Gtk.IconSize.MENU);
         cpu_label = new Gtk.Label ("CPU");
-        cpu_graph = new SysMonitor.Widgets.SysGraph(14, Gtk.IconSize.MENU);
+        cpu_graph = new SysMonitor.Widgets.SysLineGraph(40, Gtk.IconSize.MENU);
         cpu_desr = new Gtk.Label ("CPU");
         ram_label = new Gtk.Label ("MEM");
         ram_graph = new SysMonitor.Widgets.SysGraph(14, Gtk.IconSize.MENU);

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -19,17 +19,66 @@
  * Authored by: Tudor Plugaru <plugaru.tudor@gmail.com>
  */
 
+public class SysGraph : Gtk.DrawingArea {
+
+    private int _current_percent;
+    public int current_percent { 
+        set {_current_percent=value; redraw_canvas();} 
+        get {return _current_percent;} 
+    }
+
+    public SysGraph (int target_width, int target_height) {
+        set_size_request (target_width, target_height);
+        current_percent = 0;
+    }
+     
+    public override bool draw (Cairo.Context cr) {
+        int width = get_allocated_width ();
+        int height = get_allocated_height ();
+        
+        // Background
+        cr.set_source_rgb (0,0,0);
+        cr.rectangle (0, 0, width, height);
+        cr.fill ();
+        
+        // Percentage
+        var percent_height = (int) (((double)current_percent/100.0) * height);
+        var px = 0;
+        var py = height-percent_height;
+        cr.set_source_rgb (1,1,1);
+        cr.rectangle (px, py, width, percent_height);
+        cr.fill ();
+        
+        // Border
+        cr.set_source_rgb (0.2, 0.2, 0.2);
+        cr.rectangle (0, 0, width, height);
+        cr.stroke ();
+        
+        return false;
+    }
+    
+    private void redraw_canvas () {
+        var window = get_window ();
+        if (null == window) {
+            return;
+        }
+
+        var region = window.get_clip_region ();
+        // redraw the cairo canvas completely by exposing it
+        window.invalidate_region (region, true);
+        window.process_updates (true);
+    }
+}
+
 public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     private SysMonitor.Services.SettingsManager settings;
     
     private Gtk.Label cpu_label;
     private Gtk.Label cpu_desr;
-    private Gtk.Label cpu_graph;
-    
+    private SysGraph cpu_graph;
     private Gtk.Label ram_label;
     private Gtk.Label ram_desr;
-    private Gtk.Label ram_graph;
-    
+    private SysGraph ram_graph;
     private Gtk.Label network_down_label;
     private Gtk.Label network_up_label;
     private Gtk.Image icon;
@@ -55,10 +104,12 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
         settings = SysMonitor.Services.SettingsManager.get_default ();
         icon = new Gtk.Image.from_icon_name ("utilities-system-monitor-symbolic", Gtk.IconSize.MENU);
         cpu_label = new Gtk.Label ("CPU");
-        cpu_graph = new Gtk.Label ("CPU");
+        // cpu_graph = new Gtk.Label ("CPU");
+        cpu_graph = new SysGraph(14, Gtk.IconSize.MENU);
         cpu_desr = new Gtk.Label ("CPU");
         ram_label = new Gtk.Label ("MEM");
-        ram_graph = new Gtk.Label ("MEM");
+        // ram_graph = new Gtk.Label ("MEM");
+        ram_graph = new SysGraph(14, Gtk.IconSize.MENU);
         ram_desr = new Gtk.Label ("MEM");
         network_down_label = new Gtk.Label ("DOWN");
         network_down_label.set_width_chars (8);
@@ -140,12 +191,14 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
 
     public void set_cpu (int cpu_usage) {
         cpu_label.set_label (this.format_int (cpu_usage));
-        cpu_graph.set_label (this.get_percent_progress_string (cpu_usage));
+        // cpu_graph.set_label (this.get_percent_progress_string (cpu_usage));
+        cpu_graph.current_percent = cpu_usage;
     }
 
     public void set_ram (int ram_usage) {
         ram_label.set_label (this.format_int (ram_usage));
-        ram_graph.set_label (this.get_percent_progress_string (ram_usage));
+        // ram_graph.set_label (this.get_percent_progress_string (ram_usage));
+        ram_graph.current_percent = ram_usage;
     }
 
     public void set_network (int bytes_out, int bytes_in) {
@@ -190,36 +243,6 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
             return "0%i%%".printf (number);
         } else {
             return "%i%%".printf (number);
-        }
-    }
-    
-    private string get_percent_progress_string(int number) {
-        if (number < 25) {
-            if (number < 12.5) {
-                return "░░░░";
-            } else {
-                return "▒░░░";
-            }
-        } else if (number < 50) {
-            if (number < 37.5) {
-                return "█░░░";
-            } else {
-                return "█▒░░";
-            }
-        } else if (number < 75) {
-            if (number < 62.5) {
-                return "██░░";
-            } else {
-                return "██▒░";
-            }
-        } else if (number < 100) {
-            if (number < 87.5) {
-                return "███░";
-            } else {
-                return "███▒";
-            }
-        } else {
-            return "████";
         }
     }
 }

--- a/src/Widgets/SettingsView.vala
+++ b/src/Widgets/SettingsView.vala
@@ -23,6 +23,8 @@ public class SysMonitor.Widgets.SettingsView : Gtk.Grid {
     private Wingpanel.Widgets.Switch show_cpu_switch;
     private Wingpanel.Widgets.Switch show_ram_switch;
     private Wingpanel.Widgets.Switch show_network_switch;
+    private Wingpanel.Widgets.Switch show_desr_switch;
+    private Wingpanel.Widgets.Switch show_graph_switch;
     private Wingpanel.Widgets.Switch show_icon_switch;
     private SysMonitor.Services.SettingsManager settings;
 
@@ -37,17 +39,23 @@ public class SysMonitor.Widgets.SettingsView : Gtk.Grid {
         show_cpu_switch = new Wingpanel.Widgets.Switch (_ ("Display CPU usage"), settings.show_cpu);
         show_ram_switch = new Wingpanel.Widgets.Switch (_ ("Display RAM usage"), settings.show_ram);
         show_network_switch = new Wingpanel.Widgets.Switch (_ ("Display Network usage"), settings.show_network);
+        show_desr_switch = new Wingpanel.Widgets.Switch (_ ("Display label"), settings.show_desr);
+        show_graph_switch = new Wingpanel.Widgets.Switch (_ ("Display graph"), settings.show_graph);
         show_icon_switch = new Wingpanel.Widgets.Switch (_ ("Display icon"), settings.show_icon);
 
         settings.schema.bind("show-ram", show_ram_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
         settings.schema.bind("show-cpu", show_cpu_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
         settings.schema.bind("show-network", show_network_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind("show-desr", show_desr_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind("show-graph", show_graph_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
         settings.schema.bind("show-icon", show_icon_switch.get_switch(), "active", SettingsBindFlags.DEFAULT);
 
         attach (show_cpu_switch,  0, 1, 1, 1);
         attach (show_ram_switch,  0, 2, 1, 1);
         attach (show_network_switch, 0, 3, 1, 1);
-        attach (show_icon_switch, 0, 4, 1, 1);
+        attach (show_desr_switch, 0, 4, 1, 1);
+        attach (show_graph_switch, 0, 5, 1, 1);
+        attach (show_icon_switch, 0, 6, 1, 1);
     }
 }
 

--- a/src/Widgets/SysGraph.vala
+++ b/src/Widgets/SysGraph.vala
@@ -1,0 +1,72 @@
+/*-
+ * Copyright (c) 2018 Tudor Plugaru (https://github.com/PlugaruT/wingpanel-indicator-sys-monitor)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ * Authored by: Tudor Plugaru <plugaru.tudor@gmail.com>
+ */
+
+public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
+    private double[] bg_color = {0.0, 0.0, 0.0, 1.0};
+    private double[] pecent_color = {1.0, 1.0, 1.0, 1.0};
+    private double[] stroke_color = {0.2, 0.2, 0.2, 1.0};
+    
+    private int _current_percent;
+    public int current_percent { 
+        set {_current_percent=value; redraw_canvas();} 
+        get {return _current_percent;} 
+    }
+
+    public SysGraph (int target_width, int target_height) {
+        set_size_request (target_width, target_height);
+        current_percent = 0;
+    }
+     
+    public override bool draw (Cairo.Context cr) {
+        int width = get_allocated_width ();
+        int height = get_allocated_height ();
+        
+        // Background
+        cr.set_source_rgba (bg_color[0],bg_color[1],bg_color[2],bg_color[3]);
+        cr.rectangle (0, 0, width, height);
+        cr.fill ();
+        
+        // Percentage
+        var percent_height = (int) (((double)current_percent/100.0) * height);
+        var px = 0;
+        var py = height-percent_height;
+        cr.set_source_rgba (pecent_color[0],pecent_color[1],pecent_color[2],pecent_color[3]);
+        cr.rectangle (px, py, width, percent_height);
+        cr.fill ();
+        
+        // Border
+        cr.set_source_rgba (stroke_color[0],stroke_color[1],stroke_color[2],stroke_color[3]);
+        cr.rectangle (0, 0, width, height);
+        cr.stroke ();
+        
+        return false;
+    }
+    
+    private void redraw_canvas () {
+        var window = get_window ();
+        if (null == window) {
+            return;
+        }
+        var region = window.get_clip_region ();
+        // redraw the cairo canvas completely by exposing it
+        window.invalidate_region (region, true);
+    }
+}

--- a/src/Widgets/SysGraph.vala
+++ b/src/Widgets/SysGraph.vala
@@ -33,6 +33,7 @@ public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
     public SysGraph (int target_width, int target_height) {
         set_size_request (target_width, target_height);
         current_percent = 0;
+        Services.BackgroundManager.get_default ().background_state_changed.connect (update_background);
     }
      
     public override bool draw (Cairo.Context cr) {
@@ -68,5 +69,50 @@ public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
         var region = window.get_clip_region ();
         // redraw the cairo canvas completely by exposing it
         window.invalidate_region (region, true);
+    }
+    
+    private void update_background (Services.BackgroundState state, uint animation_duration) {
+        // Update color of percentage bar and stroke
+        switch (state) {
+            case Services.BackgroundState.DARK:
+            case Services.BackgroundState.TRANSLUCENT_DARK:
+            {
+                // Light Wingpanel background
+                bg_color = {1.0, 1.0, 1.0, 1.0};
+                pecent_color = {0.0, 0.0, 0.0, 1.0};
+                stroke_color = {0.5, 0.5, 0.5, 0.5};
+                break;
+            }
+            case Services.BackgroundState.MAXIMIZED:
+            case Services.BackgroundState.LIGHT:
+            case Services.BackgroundState.TRANSLUCENT_LIGHT:
+            {
+                // Dark Wingpanel background
+                bg_color = {0.0, 0.0, 0.0, 1.0};
+                pecent_color = {1.0, 1.0, 1.0, 1.0};
+                stroke_color = {0.5, 0.5, 0.5, 0.5};
+                break;
+            }
+        }
+        
+        switch (state) {
+            case Services.BackgroundState.DARK :
+            case Services.BackgroundState.MAXIMIZED:
+            case Services.BackgroundState.LIGHT:
+            {
+                // Transperent background
+                bg_color[3] = 0.0;
+                break;
+            }
+            case Services.BackgroundState.TRANSLUCENT_DARK:
+            case Services.BackgroundState.TRANSLUCENT_LIGHT:
+            {
+                // Translucent background
+                bg_color[3] = 0.5;
+                break;
+            }
+        }
+        
+        redraw_canvas ();
     }
 }

--- a/src/Widgets/SysGraph.vala
+++ b/src/Widgets/SysGraph.vala
@@ -20,11 +20,11 @@
  */
 
 public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
-    private double[] bg_color = {0.0, 0.0, 0.0, 1.0};
-    private double[] pecent_color = {1.0, 1.0, 1.0, 1.0};
-    private double[] stroke_color = {0.2, 0.2, 0.2, 1.0};
+    protected double[] bg_color = {0.0, 0.0, 0.0, 1.0};
+    protected double[] pecent_color = {1.0, 1.0, 1.0, 1.0};
+    protected double[] stroke_color = {0.2, 0.2, 0.2, 1.0};
     
-    private int _current_percent;
+    protected int _current_percent;
     public int current_percent { 
         set {_current_percent=value; redraw_canvas();} 
         get {return _current_percent;} 
@@ -61,7 +61,7 @@ public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
         return false;
     }
     
-    private void redraw_canvas () {
+    protected void redraw_canvas () {
         var window = get_window ();
         if (null == window) {
             return;
@@ -116,3 +116,59 @@ public class SysMonitor.Widgets.SysGraph : Gtk.DrawingArea {
         redraw_canvas ();
     }
 }
+
+public class SysMonitor.Widgets.SysLineGraph: SysMonitor.Widgets.SysGraph {
+    protected Queue<int> _queue = new Queue<int> ();
+    
+    public int current_percent { 
+        set {
+            int width = get_allocated_width ();
+            while (_queue.length >= width) {
+                _queue.pop_tail(); 
+            }
+            _queue.push_head(value); 
+            redraw_canvas();
+        } 
+        get {return _queue.peek_head();} 
+    }
+    
+    public SysLineGraph (int target_width, int target_height) {
+        base(target_width, target_height);
+    }
+    
+    public override bool draw (Cairo.Context cr) {
+        int width = get_allocated_width ();
+        int height = get_allocated_height ();
+        
+        // Background
+        cr.set_source_rgba (bg_color[0],bg_color[1],bg_color[2],bg_color[3]);
+        cr.rectangle (0, 0, width, height);
+        cr.fill ();
+        
+        int xb = width;
+        int yb = height;
+        
+        int last_x = xb;
+        cr.set_source_rgba (pecent_color[0],pecent_color[1],pecent_color[2],pecent_color[3]);
+        cr.move_to(xb, yb);
+        if (_queue.length > 0) {
+            for (int i=0;i<_queue.length;i++) {
+                var percent_height = (int) (((double)_queue.peek_nth(i)/100.0) * height);
+                var px = last_x - 1;
+                var py = height-percent_height;
+                cr.line_to(px, py);
+                last_x = px;
+            }
+        }
+        cr.line_to(last_x, height);
+        cr.fill ();
+        
+        // Border
+        cr.set_source_rgba (stroke_color[0],stroke_color[1],stroke_color[2],stroke_color[3]);
+        cr.rectangle (0, 0, width, height);
+        cr.stroke ();
+        
+        return false;
+    }
+}
+


### PR DESCRIPTION
Since this indicator only show percent for CPU/RAM, which is hard to determine which is for CPU or RAM.
I also add a simple graph bar for better visualization.

![screenshot from 2018-10-22 10 17 59](https://user-images.githubusercontent.com/8265230/47276824-41eb4e80-d5e4-11e8-968e-6fb8818162cd.png)
