### PR TITLE
Network speed in bits and corresponding switch in setting

### DIFF
--- a/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
+++ b/schemas/com.github.plugarut.wingpanel-indicator-sys-monitor.gschema.xml
@@ -31,5 +31,10 @@
 			<summary>Show sys-monitor icon in Wingpanel</summary>
 			<description></description>
 		</key>
+    <key type="b" name="network-in-bits">
+			<default>false</default>
+			<summary>Show network in bits or Bytes</summary>
+			<description></description>
+		</key>
 	</schema>
 </schemalist>

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -28,6 +28,7 @@ public class SysMonitor.Services.SettingsManager : Granite.Services.Settings {
     public bool show_desr { set; get; }
     public bool show_graph { set; get; }
     public bool show_icon { set; get; }
+    public bool network_in_bits { set; get; }
 
     public SettingsManager () {
         base ("com.github.plugarut.wingpanel-indicator-sys-monitor");

--- a/src/Services/Utils.vala
+++ b/src/Services/Utils.vala
@@ -71,8 +71,9 @@ public class SysMonitor.Services.Utils  : GLib.Object {
         return pattern.printf (val);
     }
 
-    public static string format_net_speed (int bytes, bool round) {
+    public static string format_net_speed (int bytes, bool round, bool inbits) {
         string[] sizes = { " B/s", "KB/s", "MB/s", "GB/s", "TB/s" };
+        string[] sizes_in_bits = { " b/s", "Kb/s", "Mb/s", "Gb/s", "Tb/s" };
         double len = (double)bytes;
         int order = 0;
         string speed = "";
@@ -84,10 +85,15 @@ public class SysMonitor.Services.Utils  : GLib.Object {
             len = 0;
             order = 0;
         }
+        string unit = sizes[order];
+        if (inbits == true){
+            len = len*8;
+            unit = sizes_in_bits[order];
+        }
         if (round == true) {
-            speed = "%3.0f %s".printf (len, sizes[order]);
+            speed = "%3.0f %s".printf(len, unit);
         } else  {
-            speed = "%3.2f %s".printf (len, sizes[order]);
+            speed = "%3.2f %s".printf(len, unit);
         }
 
         return speed;

--- a/src/Services/Utils.vala
+++ b/src/Services/Utils.vala
@@ -71,7 +71,7 @@ public class SysMonitor.Services.Utils  : GLib.Object {
         return pattern.printf (val);
     }
 
-    public static string format_net_speed (int bytes, bool round, bool inbits) {
+    public static string format_net_speed (int bytes, bool round, bool in_bits) {
         string[] sizes = { " B/s", "KB/s", "MB/s", "GB/s", "TB/s" };
         string[] sizes_in_bits = { " b/s", "Kb/s", "Mb/s", "Gb/s", "Tb/s" };
         double len = (double)bytes;
@@ -86,14 +86,14 @@ public class SysMonitor.Services.Utils  : GLib.Object {
             order = 0;
         }
         string unit = sizes[order];
-        if (inbits == true){
+        if (in_bits == true){
             len = len*8;
             unit = sizes_in_bits[order];
         }
         if (round == true) {
-            speed = "%3.0f %s".printf(len, unit);
+            speed = "%3.0f %s".printf (len, unit);
         } else  {
-            speed = "%3.2f %s".printf(len, unit);
+            speed = "%3.2f %s".printf (len, unit);
         }
 
         return speed;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -149,8 +149,8 @@ public class SysMonitor.Widgets.DisplayWidget : Gtk.Grid {
     }
 
     public void set_network (int bytes_out, int bytes_in) {
-        network_up_label.set_label (SysMonitor.Services.Utils.format_net_speed (bytes_out, true));
-        network_down_label.set_label (SysMonitor.Services.Utils.format_net_speed (bytes_in, true));
+        network_up_label.set_label (SysMonitor.Services.Utils.format_net_speed (bytes_out, true, settings.network_in_bits));
+        network_down_label.set_label (SysMonitor.Services.Utils.format_net_speed (bytes_in, true, settings.network_in_bits));
     }
 
     private void update_cpu_revelear () {

--- a/src/Widgets/MainView.vala
+++ b/src/Widgets/MainView.vala
@@ -20,6 +20,8 @@
  */
 
 public class SysMonitor.Widgets.MainView : Gtk.Box {
+    private SysMonitor.Services.SettingsManager settings;
+
     private SysMonitor.Widgets.MainViewRow ram_row;
     private SysMonitor.Widgets.MainViewRow swap_row;
     private SysMonitor.Widgets.MainViewRow freq_row;
@@ -34,6 +36,8 @@ public class SysMonitor.Widgets.MainView : Gtk.Box {
     }
 
     construct {
+        settings = SysMonitor.Services.SettingsManager.get_default ();
+
         ram_row = new SysMonitor.Widgets.MainViewRow (_ ("Ram:"));
         swap_row = new SysMonitor.Widgets.MainViewRow (_ ("Swap:"));
         freq_row = new SysMonitor.Widgets.MainViewRow (_ ("Frequency:"));
@@ -75,8 +79,8 @@ public class SysMonitor.Widgets.MainView : Gtk.Box {
     }
 
     public void update_net_speed (int bytes_out, int bytes_in) {
-        var download = SysMonitor.Services.Utils.format_net_speed (bytes_in, false);
-        var upload = SysMonitor.Services.Utils.format_net_speed (bytes_out, false);
+        var download = SysMonitor.Services.Utils.format_net_speed (bytes_in, false, settings.network_in_bits);
+        var upload = SysMonitor.Services.Utils.format_net_speed (bytes_out, false, settings.network_in_bits);
         network_down_row.update_value (download);
         network_up_row.update_value (upload);
     }

--- a/src/Widgets/SettingsView.vala
+++ b/src/Widgets/SettingsView.vala
@@ -26,6 +26,7 @@ public class SysMonitor.Widgets.SettingsView : Gtk.Grid {
     private Wingpanel.Widgets.Switch show_desr_switch;
     private Wingpanel.Widgets.Switch show_graph_switch;
     private Wingpanel.Widgets.Switch show_icon_switch;
+    private Wingpanel.Widgets.Switch network_in_bits_switch;
     private SysMonitor.Services.SettingsManager settings;
 
     public SettingsView () {
@@ -42,20 +43,23 @@ public class SysMonitor.Widgets.SettingsView : Gtk.Grid {
         show_desr_switch = new Wingpanel.Widgets.Switch (_ ("Display label"), settings.show_desr);
         show_graph_switch = new Wingpanel.Widgets.Switch (_ ("Display graph"), settings.show_graph);
         show_icon_switch = new Wingpanel.Widgets.Switch (_ ("Display icon"), settings.show_icon);
+        network_in_bits_switch = new Wingpanel.Widgets.Switch (_ ("Network in bits"), settings.network_in_bits);
 
-        settings.schema.bind ("show-ram",     show_ram_switch.get_switch (),     "active", SettingsBindFlags.DEFAULT);
-        settings.schema.bind ("show-cpu",     show_cpu_switch.get_switch (),     "active", SettingsBindFlags.DEFAULT);
-        settings.schema.bind ("show-network", show_network_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-        settings.schema.bind ("show-desr",    show_desr_switch.get_switch (),    "active", SettingsBindFlags.DEFAULT);
-        settings.schema.bind ("show-graph",   show_graph_switch.get_switch (),   "active", SettingsBindFlags.DEFAULT);
-        settings.schema.bind ("show-icon",    show_icon_switch.get_switch (),    "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-ram",           show_ram_switch.get_switch (),          "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-cpu",           show_cpu_switch.get_switch (),          "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-network",       show_network_switch.get_switch (),      "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-desr",          show_desr_switch.get_switch (),         "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-graph",         show_graph_switch.get_switch (),        "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("show-icon",          show_icon_switch.get_switch (),         "active", SettingsBindFlags.DEFAULT);
+        settings.schema.bind ("network-in-bits",    network_in_bits_switch.get_switch (),   "active", SettingsBindFlags.DEFAULT);
 
-        attach (show_cpu_switch,     0, 1, 1, 1);
-        attach (show_ram_switch,     0, 2, 1, 1);
-        attach (show_network_switch, 0, 3, 1, 1);
-        attach (show_desr_switch,    0, 4, 1, 1);
-        attach (show_graph_switch,   0, 5, 1, 1);
-        attach (show_icon_switch,    0, 6, 1, 1);
+        attach (show_cpu_switch,        0, 1, 1, 1);
+        attach (show_ram_switch,        0, 2, 1, 1);
+        attach (show_network_switch,    0, 3, 1, 1);
+        attach (show_desr_switch,       0, 4, 1, 1);
+        attach (show_graph_switch,      0, 5, 1, 1);
+        attach (show_icon_switch,       0, 6, 1, 1);
+        attach (network_in_bits_switch, 0, 7, 1, 1);
     }
 }
 


### PR DESCRIPTION
This push adds an option to show network speed in bits per sec.
The default option is still B/s but you can change the switch in setting to enable b/s.
This resolve the https://github.com/PlugaruT/wingpanel-indicator-sys-monitor/issues/22