### PR TITLE
README: Complete installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,22 @@ I recommend to switch to the [new implementation](https://github.com/PlugaruT/wi
 
 ## Building and Installation
 
-You'll need the following dependencies:
+### Elementary
+
+Clone the repository:
 
 ```
-libglib2.0-dev
-libgtop2-dev
-libgranite-dev
-libgtk-3-dev
-libwingpanel-2.0-dev
-meson
-valac
+git clone https://github.com/PlugaruT/wingpanel-indicator-sys-monitor.git
+cd wingpanel-indicator-sys-monitor
 ```
 
-## Elementary
+Install the dependencies:
 
 ```
 sudo apt install libgtop2-dev libgranite-dev libgtk-3-dev libwingpanel-2.0-dev meson valac
 ```
 
-Run `meson` to configure the build environment and then `ninja` to build
+Run `meson` to configure the build environment and then `ninja` to build the project:
 
 ```
 meson build --prefix=/usr
@@ -33,17 +30,18 @@ cd build
 ninja
 ```
 
-To install, use `ninja install`
+Install the built application:
 
 ```
 sudo ninja install
 ```
 
-## Arch Linux
+### Arch Linux
+
 Arch Linux users can find Wingpanel Indicator Sys Monitor under the name [wingpanel-indicator-sys-monitor-git](https://aur.archlinux.org/packages/wingpanel-indicator-sys-monitor-git/) in the **AUR**:
 
 `aurman -S wingpanel-indicator-sys-monitor-git`
 
-### Notes
+## Notes
 
  - Special thanks for [@RyanDam](https://github.com/RyanDam/) for the graph implementation!


### PR DESCRIPTION
Fixes #43 (based in the template from [this comment](https://github.com/PlugaruT/wingpanel-indicator-sys-monitor/issues/23#issuecomment-431669394) by @Sqll), and uses the correct heading levels to produce the following content tree:

    Wingpanel System Monitor Indicator
    ├╴Building and Installation
    │ ├╴Elementary
    │ └╴Arch Linux
    └╴Notes

/cc @KillYourFM